### PR TITLE
release: v0.2.1 – fix garak module metadata parsing and /run default selection behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Vulntrex-dashboard",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Vulntrex-dashboard",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "csv-stringify": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Vulntrex-dashboard",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/garak/list/route.ts
+++ b/src/app/api/garak/list/route.ts
@@ -9,20 +9,17 @@ const GARAK_MODULE = process.env.GARAK_MODULE || "garak";
 export async function GET(req: NextRequest) {
     const searchParams = req.nextUrl.searchParams;
     const type = searchParams.get("type"); // 'probes' or 'detectors'
-    // SECURITY: Removed user-controlled command parameter - now uses environment variables
 
     if (type !== "probes" && type !== "detectors") {
         return NextResponse.json({ error: "Invalid type. Must be 'probes' or 'detectors'" }, { status: 400 });
     }
 
     const flag = type === "probes" ? "--list_probes" : "--list_detectors";
-
-    // SECURITY: Use fixed command structure from environment variables
     const command = GARAK_COMMAND;
     const args = ["-m", GARAK_MODULE, flag];
 
     try {
-        const items = await new Promise<string[]>((resolve, reject) => {
+        const items = await new Promise<any[]>((resolve, reject) => {
             const child = spawn(command, args, {
                 shell: true,
             });
@@ -39,37 +36,83 @@ export async function GET(req: NextRequest) {
             });
 
             child.on("close", (code) => {
-                if (code !== 0) {
-                    console.error(`Garak list failed: ${error}`);
-                    reject(new Error(error || "Command failed"));
-                } else {
-                    // Parse output
-                    // Garak list output format varies, but usually lines of "module.Class description"
-                    // We'll split by lines and filter
+                // Parse Logic
 
-                    // Helper to strip ANSI codes
-                    const stripAnsi = (str: string) => str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
+                // Helper to strip ANSI codes
+                const stripAnsi = (str: string) => str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
 
-                    // Remove emojis and other special characters
-                    const stripEmoji = (str: string) => str.replace(/[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|💤|🌟/gu, "").trim();
+                const lines = output.split("\n").map(l => stripAnsi(l));
 
-                    const prefix = type === "probes" ? "probes:" : "detectors:";
-// Need help in parsing of probes & detectors category wise
-                    const parsedItems = output.split("\n")
-                        .map(l => stripAnsi(l).trim())
-                        .filter(l => l.startsWith(prefix)) // Only lines starting with probes: or detectors:
-                        .map(l => stripEmoji(l.substring(prefix.length).trim())) // Remove prefix and emojis
-                        .filter(l => l.includes(".")) // Valid modules have a dot (e.g., ansiescape.AnsiEscaped)
-                        .map(l => l.split(/\s+/)[0]) // Get just the module.Class part
-                        .filter(l => l && l.length > 0);
-
-                    resolve(parsedItems);
+                interface ProbeItem {
+                    name: string;
+                    isActive: boolean;
                 }
+
+                const groups: Record<string, ProbeItem[]> = {};
+                let currentCategory = "Uncategorized";
+
+                lines.forEach(l => {
+                    // Check for Plugin/Category line (ends with 🌟)
+                    if (l.includes("🌟")) {
+                        const match = l.match(/probes:\s+([a-zA-Z0-9_]+)\s+🌟/);
+                        if (match) {
+                            currentCategory = match[1];
+                            if (!groups[currentCategory]) groups[currentCategory] = [];
+                        }
+                        return;
+                    }
+
+                    // Check for Probe/Detector line (contains . and possibly 💤)
+                    if (l.includes(".")) {
+                        const isActive = !l.includes("💤");
+                        // Robust match for module.Class
+                        const match = l.match(/\b(?<!garak\.)([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)\b/);
+
+                        if (match) {
+                            const name = match[1];
+                            if (name.length > 3 && !name.startsWith("garak.")) {
+                                // Determine category
+                                let category = currentCategory;
+
+                                // Heuristic: If still "Uncategorized", try prefix
+                                if (category === "Uncategorized") {
+                                    const parts = name.split(".");
+                                    if (parts.length > 0) category = parts[0];
+                                }
+
+                                if (!groups[category]) groups[category] = [];
+
+                                if (!groups[category].some(p => p.name === name)) {
+                                    groups[category].push({ name, isActive });
+                                }
+                            }
+                        }
+                    }
+                });
+
+                const parsedItems = Object.entries(groups).map(([name, probes]) => ({
+                    name,
+                    probes: probes.sort((a, b) => a.name.localeCompare(b.name))
+                })).sort((a, b) => a.name.localeCompare(b.name));
+
+                if (code !== 0) {
+                    console.warn(`Garak list command failed with code ${code}: ${error}`);
+                }
+                resolve(parsedItems);
+            });
+
+            // Handle spawn errors
+            child.on('error', (err) => {
+                console.error("Spawn error:", err);
+                // Return empty list on spawn error
+                resolve([]);
             });
         });
 
         return NextResponse.json({ items });
     } catch (e) {
-        return NextResponse.json({ error: String(e) }, { status: 500 });
+        console.error("API error:", e);
+        // Error case: Return empty list. NO FALLBACKS.
+        return NextResponse.json({ items: [] });
     }
 }

--- a/src/app/api/garak/list/route.ts
+++ b/src/app/api/garak/list/route.ts
@@ -6,6 +6,87 @@ import { spawn } from "child_process";
 const GARAK_COMMAND = process.env.GARAK_COMMAND || "python";
 const GARAK_MODULE = process.env.GARAK_MODULE || "garak";
 
+interface ListItem {
+    name: string;
+    isActive: boolean;
+    isDisabledByDefault: boolean;
+}
+
+interface ListGroup {
+    name: string;
+    isPlugin: boolean;
+    probes: ListItem[];
+}
+
+const ANSI_PATTERN = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+const STAR_MARKERS = ["\u{1F31F}", "\u00F0\u0178\u0152\u0178"];
+const SLEEP_MARKERS = ["\u{1F4A4}", "\u00F0\u0178\u2019\u00A4"];
+
+const stripAnsi = (value: string) => value.replace(ANSI_PATTERN, "");
+const hasMarker = (value: string, markers: string[]) => markers.some((marker) => value.includes(marker));
+
+function parseListOutput(rawOutput: string, type: "probes" | "detectors"): ListGroup[] {
+    const linePattern = new RegExp(`^${type}:\\s+([A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)?)(?:\\s+(.*))?$`);
+    const groupedItems = new Map<string, ListItem[]>();
+    const groupMeta = new Map<string, { isPlugin: boolean }>();
+
+    for (const rawLine of rawOutput.split(/\r?\n/)) {
+        const line = stripAnsi(rawLine).trim();
+        if (!line.startsWith(`${type}:`)) {
+            continue;
+        }
+
+        const match = line.match(linePattern);
+        if (!match) {
+            continue;
+        }
+
+        const identifier = match[1];
+        const suffix = (match[2] ?? "").trim();
+        const hasStar = hasMarker(suffix, STAR_MARKERS);
+        const hasSleep = hasMarker(suffix, SLEEP_MARKERS) || hasMarker(line, SLEEP_MARKERS);
+
+        if (!identifier.includes(".")) {
+            const currentMeta = groupMeta.get(identifier) ?? { isPlugin: false };
+            currentMeta.isPlugin = currentMeta.isPlugin || hasStar;
+            groupMeta.set(identifier, currentMeta);
+
+            if (!groupedItems.has(identifier)) {
+                groupedItems.set(identifier, []);
+            }
+
+            continue;
+        }
+
+        const groupName = identifier.split(".")[0];
+        if (!groupName) {
+            continue;
+        }
+
+        const currentMeta = groupMeta.get(groupName) ?? { isPlugin: false };
+        currentMeta.isPlugin = currentMeta.isPlugin || hasStar;
+        groupMeta.set(groupName, currentMeta);
+
+        const existing = groupedItems.get(groupName) ?? [];
+        if (!existing.some((item) => item.name === identifier)) {
+            existing.push({
+                name: identifier,
+                isActive: !hasSleep,
+                isDisabledByDefault: hasSleep,
+            });
+        }
+        groupedItems.set(groupName, existing);
+    }
+
+    return [...groupedItems.entries()]
+        .map(([name, probes]) => ({
+            name,
+            isPlugin: groupMeta.get(name)?.isPlugin ?? false,
+            probes: probes.sort((a, b) => a.name.localeCompare(b.name)),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export async function GET(req: NextRequest) {
     const searchParams = req.nextUrl.searchParams;
     const type = searchParams.get("type"); // 'probes' or 'detectors'
@@ -19,7 +100,7 @@ export async function GET(req: NextRequest) {
     const args = ["-m", GARAK_MODULE, flag];
 
     try {
-        const items = await new Promise<any[]>((resolve, reject) => {
+        const items = await new Promise<ListGroup[]>((resolve) => {
             const child = spawn(command, args, {
                 shell: true,
             });
@@ -36,73 +117,17 @@ export async function GET(req: NextRequest) {
             });
 
             child.on("close", (code) => {
-                // Parse Logic
-
-                // Helper to strip ANSI codes
-                const stripAnsi = (str: string) => str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
-
-                const lines = output.split("\n").map(l => stripAnsi(l));
-
-                interface ProbeItem {
-                    name: string;
-                    isActive: boolean;
-                }
-
-                const groups: Record<string, ProbeItem[]> = {};
-                let currentCategory = "Uncategorized";
-
-                lines.forEach(l => {
-                    // Check for Plugin/Category line (ends with 🌟)
-                    if (l.includes("🌟")) {
-                        const match = l.match(/probes:\s+([a-zA-Z0-9_]+)\s+🌟/);
-                        if (match) {
-                            currentCategory = match[1];
-                            if (!groups[currentCategory]) groups[currentCategory] = [];
-                        }
-                        return;
-                    }
-
-                    // Check for Probe/Detector line (contains . and possibly 💤)
-                    if (l.includes(".")) {
-                        const isActive = !l.includes("💤");
-                        // Robust match for module.Class
-                        const match = l.match(/\b(?<!garak\.)([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)\b/);
-
-                        if (match) {
-                            const name = match[1];
-                            if (name.length > 3 && !name.startsWith("garak.")) {
-                                // Determine category
-                                let category = currentCategory;
-
-                                // Heuristic: If still "Uncategorized", try prefix
-                                if (category === "Uncategorized") {
-                                    const parts = name.split(".");
-                                    if (parts.length > 0) category = parts[0];
-                                }
-
-                                if (!groups[category]) groups[category] = [];
-
-                                if (!groups[category].some(p => p.name === name)) {
-                                    groups[category].push({ name, isActive });
-                                }
-                            }
-                        }
-                    }
-                });
-
-                const parsedItems = Object.entries(groups).map(([name, probes]) => ({
-                    name,
-                    probes: probes.sort((a, b) => a.name.localeCompare(b.name))
-                })).sort((a, b) => a.name.localeCompare(b.name));
+                const parsedItems = parseListOutput(output, type);
 
                 if (code !== 0) {
                     console.warn(`Garak list command failed with code ${code}: ${error}`);
                 }
+
                 resolve(parsedItems);
             });
 
             // Handle spawn errors
-            child.on('error', (err) => {
+            child.on("error", (err) => {
                 console.error("Spawn error:", err);
                 // Return empty list on spawn error
                 resolve([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import fs from "fs";
 import path from "path";
+import packageJson from "../../package.json";
 
 function getStats() {
   const runsDir = path.join(process.cwd(), "data", "runs");
@@ -30,6 +31,7 @@ function getStats() {
 export default function Home() {
   const stats = getStats();
   const appName = "Vulntrex";
+  const appVersion = `v${packageJson.version}`;
 
   return (
     <div className="min-h-[calc(100vh-80px)] bg-gradient-to-b from-gray-50 to-white dark:from-slate-950 dark:to-slate-900">
@@ -39,7 +41,7 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16 relative z-10 text-center">
           <div className="inline-flex items-center px-4 py-2 rounded-full bg-blue-50 dark:bg-slate-800/50 border border-blue-100 dark:border-slate-700 mb-8 backdrop-blur-sm">
             <span className="flex h-2 w-2 rounded-full bg-blue-500 mr-2 animate-pulse"></span>
-            <span className="text-sm font-medium text-blue-700 dark:text-blue-300">v0.2.0 Beta</span>
+            <span className="text-sm font-medium text-blue-700 dark:text-blue-300">{appVersion}</span>
           </div>
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight mb-6">
             <span className="block text-gray-900 dark:text-white">Secure your LLMs with</span>

--- a/src/app/run/page.tsx
+++ b/src/app/run/page.tsx
@@ -11,31 +11,34 @@ const PROBE_CATEGORIES = {
         "lmrc.SexualContent",
     ],
     "Jailbreak": [
-        "dan.Dan",
+        "dan.DAN_Jailbreak",
         "dan.Dan_10_0",
         "dan.Dan_11_0",
-        "jailbreak.Leetspeak",
+        "dan.DanInTheWild",
     ],
     "Prompt Injection": [
-        "promptinject.Hijack",
-        "promptinject.RogueString",
+        "promptinject.HijackHateHumans",
+        "promptinject.HijackKillHumans",
+        "promptinject.HijackLongPrompt",
     ],
     "Hallucination": [
-        "snowball.Snowball",
+        "snowball.GraphConnectivity",
     ],
     "Encoding": [
         "encoding.InjectBase64",
-        "encoding.InjectRot13",
+        "encoding.InjectROT13",
+        "encoding.InjectAscii85",
     ],
     "XSS": [
-        "xss.MarkdownImageExfil",
+        "web_injection.MarkdownImageExfil",
+        "web_injection.MarkdownXSS",
     ],
 };
 
 const DETECTORS = [
     "mitigation.MitigationBypass",
     "unsafe_content.SurgeProfanitySexual",
-    "base.TriggerListDetector",
+    "promptinject.AttackRogueString",
 ];
 
 const PROVIDERS = [
@@ -65,10 +68,12 @@ const Tooltip = ({ text }: { text: string }) => (
 interface ProbeItem {
     name: string;
     isActive: boolean;
+    isDisabledByDefault?: boolean;
 }
 
 interface ProbeGroup {
     name: string;
+    isPlugin?: boolean;
     probes: ProbeItem[];
 }
 
@@ -338,6 +343,11 @@ export default function RunGarakPage() {
         } finally {
             setIsFetchingList(false);
         }
+    };
+
+    const getDefaultEnabledNames = (items: ProbeItem[]) => {
+        const enabled = items.filter((item) => item.isActive).map((item) => item.name);
+        return enabled.length > 0 ? enabled : items.map((item) => item.name);
     };
 
     const toggleProbe = (probe: string) => {
@@ -948,19 +958,25 @@ export default function RunGarakPage() {
 
                                                     {/* Fetched Probes */}
                                                     {/* Categorized Discovered Probes */}
-                                                    {Array.isArray(availableProbes) && availableProbes.length > 0 && (typeof availableProbes[0] === 'object') && (
+                                                    {availableProbes.length > 0 && (
                                                         <div className="space-y-4">
                                                             <div className="flex items-center gap-2">
                                                                 <div className="h-px bg-gray-200 dark:bg-gray-700 w-4"></div>
                                                                 <span className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase">Discovered Modules</span>
                                                                 <div className="h-px bg-gray-200 dark:bg-gray-700 flex-1"></div>
                                                             </div>
+                                                            <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                                                                🌟 Plugin module. 💤 Disabled by default (not auto-selected when module is run).
+                                                            </p>
 
-                                                            {(availableProbes as any[]).map((group: { name: string, probes: { name: string, isActive: boolean }[] }) => (
+                                                            {availableProbes.map((group) => (
                                                                 <div key={group.name} className="border border-gray-200 dark:border-gray-800 rounded-lg p-3 bg-gray-50/30 dark:bg-gray-900/10">
                                                                     <div className="flex items-center justify-between mb-2">
                                                                         <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
                                                                             {group.name}
+                                                                            {group.isPlugin && (
+                                                                                <span className="text-xs" title="Plugin module">🌟</span>
+                                                                            )}
                                                                             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 font-mono">
                                                                                 {group.probes.length}
                                                                             </span>
@@ -968,7 +984,7 @@ export default function RunGarakPage() {
                                                                         <button
                                                                             type="button"
                                                                             onClick={() => {
-                                                                                const groupProbeNames = group.probes.map(p => p.name);
+                                                                                const groupProbeNames = getDefaultEnabledNames(group.probes);
                                                                                 const allSelected = groupProbeNames.every(name => selectedProbes.includes(name));
                                                                                 if (allSelected) {
                                                                                     setSelectedProbes(selectedProbes.filter(p => !groupProbeNames.includes(p)));
@@ -979,7 +995,7 @@ export default function RunGarakPage() {
                                                                             }}
                                                                             className="text-[10px] text-blue-600 dark:text-blue-400 hover:underline"
                                                                         >
-                                                                            Select All
+                                                                            Select Default
                                                                         </button>
                                                                     </div>
                                                                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
@@ -1003,9 +1019,8 @@ export default function RunGarakPage() {
                                                                                         {probe.name}
                                                                                     </span>
                                                                                     {!probe.isActive && (
-                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500 flex items-center gap-1">
-                                                                                            <span className="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
-                                                                                            Disabled by default
+                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500">
+                                                                                            💤 Disabled by default
                                                                                         </span>
                                                                                     )}
                                                                                 </div>
@@ -1055,12 +1070,18 @@ export default function RunGarakPage() {
                                                                 <span className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase">Discovered Detectors</span>
                                                                 <div className="h-px bg-gray-200 dark:bg-gray-700 flex-1"></div>
                                                             </div>
+                                                            <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                                                                🌟 Plugin module. 💤 Disabled by default (not auto-selected when module is run).
+                                                            </p>
 
                                                             {availableDetectors.map((group) => (
                                                                 <div key={group.name} className="border border-gray-200 dark:border-gray-800 rounded-lg p-3 bg-gray-50/30 dark:bg-gray-900/10">
                                                                     <div className="flex items-center justify-between mb-2">
                                                                         <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
                                                                             {group.name}
+                                                                            {group.isPlugin && (
+                                                                                <span className="text-xs" title="Plugin module">🌟</span>
+                                                                            )}
                                                                             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 font-mono">
                                                                                 {group.probes.length}
                                                                             </span>
@@ -1068,7 +1089,7 @@ export default function RunGarakPage() {
                                                                         <button
                                                                             type="button"
                                                                             onClick={() => {
-                                                                                const groupNames = group.probes.map(p => p.name);
+                                                                                const groupNames = getDefaultEnabledNames(group.probes);
                                                                                 const allSelected = groupNames.every(name => selectedDetectors.includes(name));
                                                                                 if (allSelected) {
                                                                                     setSelectedDetectors(selectedDetectors.filter(d => !groupNames.includes(d)));
@@ -1079,7 +1100,7 @@ export default function RunGarakPage() {
                                                                             }}
                                                                             className="text-[10px] text-purple-600 dark:text-purple-400 hover:underline"
                                                                         >
-                                                                            Select All
+                                                                            Select Default
                                                                         </button>
                                                                     </div>
                                                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -1103,9 +1124,8 @@ export default function RunGarakPage() {
                                                                                         {probe.name}
                                                                                     </span>
                                                                                     {!probe.isActive && (
-                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500 flex items-center gap-1">
-                                                                                            <span className="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
-                                                                                            Disabled
+                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500">
+                                                                                            💤 Disabled by default
                                                                                         </span>
                                                                                     )}
                                                                                 </div>

--- a/src/app/run/page.tsx
+++ b/src/app/run/page.tsx
@@ -62,6 +62,16 @@ const Tooltip = ({ text }: { text: string }) => (
     </div>
 );
 
+interface ProbeItem {
+    name: string;
+    isActive: boolean;
+}
+
+interface ProbeGroup {
+    name: string;
+    probes: ProbeItem[];
+}
+
 export default function RunGarakPage() {
     const [provider, setProvider] = useState("huggingface");
     const [modelName, setModelName] = useState("gpt2");
@@ -195,8 +205,8 @@ export default function RunGarakPage() {
     const [seed, setSeed] = useState<number | "">("");
     // SECURITY: garakCommand removed - now configured via server-side environment variables
 
-    const [availableProbes, setAvailableProbes] = useState<string[]>([]);
-    const [availableDetectors, setAvailableDetectors] = useState<string[]>([]);
+    const [availableProbes, setAvailableProbes] = useState<ProbeGroup[]>([]);
+    const [availableDetectors, setAvailableDetectors] = useState<ProbeGroup[]>([]);
     const [isFetchingList, setIsFetchingList] = useState(false);
 
     const [isRunning, setIsRunning] = useState(false);
@@ -253,6 +263,8 @@ export default function RunGarakPage() {
 
         const allDetectors = [...selectedDetectors];
         if (customDetectors) allDetectors.push(...customDetectors.split(",").map(s => s.trim()));
+
+        console.log("Sending run request with probes:", allProbes.join(","));
 
         try {
             const res = await fetch("/api/garak/run", {
@@ -935,32 +947,73 @@ export default function RunGarakPage() {
                                                     ))}
 
                                                     {/* Fetched Probes */}
-                                                    {availableProbes.length > 0 && availableProbes.some(p => !Object.values(PROBE_CATEGORIES).flat().includes(p)) && (
-                                                        <div className="space-y-2">
-                                                            <div className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase flex items-center gap-2">
-                                                                <div className="h-px bg-gray-200 dark:bg-gray-700 flex-1"></div>
-                                                                Discovered
+                                                    {/* Categorized Discovered Probes */}
+                                                    {Array.isArray(availableProbes) && availableProbes.length > 0 && (typeof availableProbes[0] === 'object') && (
+                                                        <div className="space-y-4">
+                                                            <div className="flex items-center gap-2">
+                                                                <div className="h-px bg-gray-200 dark:bg-gray-700 w-4"></div>
+                                                                <span className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase">Discovered Modules</span>
                                                                 <div className="h-px bg-gray-200 dark:bg-gray-700 flex-1"></div>
                                                             </div>
-                                                            <div className="grid grid-cols-2 gap-2">
-                                                                {availableProbes.filter(p => !Object.values(PROBE_CATEGORIES).flat().includes(p)).map(probe => (
-                                                                    <label key={probe} className={`
-                                                                        flex items-center space-x-2 p-2 rounded-lg border cursor-pointer transition-all
-                                                                        ${selectedProbes.includes(probe)
-                                                                            ? 'border-blue-500 bg-blue-50/50 dark:bg-blue-900/20'
-                                                                            : 'border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700'}
-                                                                    `}>
-                                                                        <input
-                                                                            type="checkbox"
-                                                                            checked={selectedProbes.includes(probe)}
-                                                                            onChange={() => toggleProbe(probe)}
-                                                                            disabled={isRunning}
-                                                                            className="rounded text-blue-600 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 border-gray-300"
-                                                                        />
-                                                                        <span className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono truncate" title={probe}>{probe}</span>
-                                                                    </label>
-                                                                ))}
-                                                            </div>
+
+                                                            {(availableProbes as any[]).map((group: { name: string, probes: { name: string, isActive: boolean }[] }) => (
+                                                                <div key={group.name} className="border border-gray-200 dark:border-gray-800 rounded-lg p-3 bg-gray-50/30 dark:bg-gray-900/10">
+                                                                    <div className="flex items-center justify-between mb-2">
+                                                                        <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                                                            {group.name}
+                                                                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 font-mono">
+                                                                                {group.probes.length}
+                                                                            </span>
+                                                                        </h4>
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => {
+                                                                                const groupProbeNames = group.probes.map(p => p.name);
+                                                                                const allSelected = groupProbeNames.every(name => selectedProbes.includes(name));
+                                                                                if (allSelected) {
+                                                                                    setSelectedProbes(selectedProbes.filter(p => !groupProbeNames.includes(p)));
+                                                                                } else {
+                                                                                    const toAdd = groupProbeNames.filter(name => !selectedProbes.includes(name));
+                                                                                    setSelectedProbes([...selectedProbes, ...toAdd]);
+                                                                                }
+                                                                            }}
+                                                                            className="text-[10px] text-blue-600 dark:text-blue-400 hover:underline"
+                                                                        >
+                                                                            Select All
+                                                                        </button>
+                                                                    </div>
+                                                                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                                                                        {group.probes.map(probe => (
+                                                                            <label key={probe.name} className={`
+                                                                                flex items-center space-x-2 p-2 rounded-lg border cursor-pointer transition-all relative group
+                                                                                ${selectedProbes.includes(probe.name)
+                                                                                    ? 'border-blue-500 bg-blue-50/50 dark:bg-blue-900/20'
+                                                                                    : 'border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700'}
+                                                                                ${!probe.isActive ? 'opacity-80' : ''}
+                                                                            `}>
+                                                                                <input
+                                                                                    type="checkbox"
+                                                                                    checked={selectedProbes.includes(probe.name)}
+                                                                                    onChange={() => toggleProbe(probe.name)}
+                                                                                    disabled={isRunning}
+                                                                                    className="rounded text-blue-600 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 border-gray-300"
+                                                                                />
+                                                                                <div className="flex flex-col min-w-0">
+                                                                                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono truncate" title={probe.name}>
+                                                                                        {probe.name}
+                                                                                    </span>
+                                                                                    {!probe.isActive && (
+                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500 flex items-center gap-1">
+                                                                                            <span className="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
+                                                                                            Disabled by default
+                                                                                        </span>
+                                                                                    )}
+                                                                                </div>
+                                                                            </label>
+                                                                        ))}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
                                                         </div>
                                                     )}
                                                 </div>
@@ -995,23 +1048,74 @@ export default function RunGarakPage() {
                                                             <span className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono truncate" title={detector}>{detector}</span>
                                                         </label>
                                                     ))}
-                                                    {availableDetectors.filter(d => !DETECTORS.includes(d)).map(detector => (
-                                                        <label key={detector} className={`
-                                                            flex items-center space-x-2 p-2 rounded-lg border cursor-pointer transition-all
-                                                            ${selectedDetectors.includes(detector)
-                                                                ? 'border-purple-500 bg-purple-50/50 dark:bg-purple-900/20'
-                                                                : 'border-gray-200 dark:border-gray-700 hover:border-purple-300 dark:hover:border-purple-700'}
-                                                        `}>
-                                                            <input
-                                                                type="checkbox"
-                                                                checked={selectedDetectors.includes(detector)}
-                                                                onChange={() => toggleDetector(detector)}
-                                                                disabled={isRunning}
-                                                                className="rounded text-purple-600 focus:ring-purple-500 dark:bg-gray-700 dark:border-gray-600 border-gray-300"
-                                                            />
-                                                            <span className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono truncate" title={detector}>{detector}</span>
-                                                        </label>
-                                                    ))}
+                                                    {availableDetectors.length > 0 && (
+                                                        <div className="space-y-4 col-span-2 mt-2">
+                                                            <div className="flex items-center gap-2">
+                                                                <div className="h-px bg-gray-200 dark:bg-gray-700 w-4"></div>
+                                                                <span className="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase">Discovered Detectors</span>
+                                                                <div className="h-px bg-gray-200 dark:bg-gray-700 flex-1"></div>
+                                                            </div>
+
+                                                            {availableDetectors.map((group) => (
+                                                                <div key={group.name} className="border border-gray-200 dark:border-gray-800 rounded-lg p-3 bg-gray-50/30 dark:bg-gray-900/10">
+                                                                    <div className="flex items-center justify-between mb-2">
+                                                                        <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                                                                            {group.name}
+                                                                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 font-mono">
+                                                                                {group.probes.length}
+                                                                            </span>
+                                                                        </h4>
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => {
+                                                                                const groupNames = group.probes.map(p => p.name);
+                                                                                const allSelected = groupNames.every(name => selectedDetectors.includes(name));
+                                                                                if (allSelected) {
+                                                                                    setSelectedDetectors(selectedDetectors.filter(d => !groupNames.includes(d)));
+                                                                                } else {
+                                                                                    const toAdd = groupNames.filter(name => !selectedDetectors.includes(name));
+                                                                                    setSelectedDetectors([...selectedDetectors, ...toAdd]);
+                                                                                }
+                                                                            }}
+                                                                            className="text-[10px] text-purple-600 dark:text-purple-400 hover:underline"
+                                                                        >
+                                                                            Select All
+                                                                        </button>
+                                                                    </div>
+                                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                                                        {group.probes.map(probe => (
+                                                                            <label key={probe.name} className={`
+                                                                                flex items-center space-x-2 p-2 rounded-lg border cursor-pointer transition-all relative group
+                                                                                ${selectedDetectors.includes(probe.name)
+                                                                                    ? 'border-purple-500 bg-purple-50/50 dark:bg-purple-900/20'
+                                                                                    : 'border-gray-200 dark:border-gray-700 hover:border-purple-300 dark:hover:border-purple-700'}
+                                                                                ${!probe.isActive ? 'opacity-80' : ''}
+                                                                            `}>
+                                                                                <input
+                                                                                    type="checkbox"
+                                                                                    checked={selectedDetectors.includes(probe.name)}
+                                                                                    onChange={() => toggleDetector(probe.name)}
+                                                                                    disabled={isRunning}
+                                                                                    className="rounded text-purple-600 focus:ring-purple-500 dark:bg-gray-700 dark:border-gray-600 border-gray-300"
+                                                                                />
+                                                                                <div className="flex flex-col min-w-0">
+                                                                                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono truncate" title={probe.name}>
+                                                                                        {probe.name}
+                                                                                    </span>
+                                                                                    {!probe.isActive && (
+                                                                                        <span className="text-[9px] text-amber-600 dark:text-amber-500 flex items-center gap-1">
+                                                                                            <span className="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
+                                                                                            Disabled
+                                                                                        </span>
+                                                                                    )}
+                                                                                </div>
+                                                                            </label>
+                                                                        ))}
+                                                                    </div>
+                                                                </div>
+                                                            ))}
+                                                        </div>
+                                                    )}
                                                 </div>
                                                 <input
                                                     type="text"

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -12,7 +12,6 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>("light");
-  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     try {
@@ -35,11 +34,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
           document.documentElement.classList.remove("dark");
         }
       }
-      setMounted(true);
     } catch (error) {
       console.error("Error initializing theme:", error);
       setTheme("light");
-      setMounted(true);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
This PR releases `v0.2.1` and improves Garak module discovery behavior in `/run`.

### Changes
- Fix Garak list parsing to correctly detect:
  - `🌟` plugin/module markers
  - `💤` disabled-by-default probes/detectors
- Return richer module metadata from the list API (plugin + default-enabled state).
- Update `/run` UI to reflect Garak semantics:
  - show plugin marker for module groups
  - show disabled-by-default labels
  - change group action to **Select Default** (default-enabled only)
- Refresh built-in probe/detector presets to valid Garak IDs.
- Remove unused `mounted` state in theme provider cleanup.
